### PR TITLE
update config file to reflect correct origin

### DIFF
--- a/telegraf.conf
+++ b/telegraf.conf
@@ -13,7 +13,7 @@
     ## Name of the measurement 
     name = "ifcounters"
 
-    origin = "openconfig-interfaces"
+    origin = "openconfig"
     path = "/interfaces/interface/state/counters"
 
     subscription_mode = "sample"
@@ -23,7 +23,7 @@
     ## Name of the measurement 
     name = "openconfig_bgp"
 
-    origin = "openconfig-bgp"
+    origin = "openconfig"
     path = "/network-instances/network-instance/protocols/protocol/bgp/"
 
     subscription_mode = "sample"


### PR DESCRIPTION
The `origin` can be either `openconfig` or `eos_native`, in 4.24+ the origin is validated and `openconfig-interfaces`, `openconfig-bgp` is not a valid origin (this was not validated before).